### PR TITLE
Improve readability of keyword

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -74,5 +74,7 @@ const
 
 module.exports = {
   keyword,
+  icon,
+  name: 'Manage Hotel applications',
   fn
 }


### PR DESCRIPTION
Adding a short description of the plugin improves readability before typing the whole keyword.
At the moment there's no feedback about the plugin on the result view.

![screenshot](https://cloud.githubusercontent.com/assets/16964209/24576417/7864fd6a-1670-11e7-95c8-e0262040361c.png)
